### PR TITLE
Fix typo in CDN status slug

### DIFF
--- a/src/ServerScriptService/MainModule.lua
+++ b/src/ServerScriptService/MainModule.lua
@@ -68,7 +68,7 @@ function DowntimeService.GetCDNAPIStatus()
 	local GetStatus = HttpService:GetAsync(sumurl)
 
 	local Data = HttpService:JSONDecode(GetStatus)
-	local Table = ReturnTableThroughSlug("roblox-s-cdn-api-endpoint", Data)
+	local Table = ReturnTableThroughSlug("cdn-api-endpoint", Data)
 
 	return Table.status -- Will return "up", "degraded" or "down"
 end


### PR DESCRIPTION
A typo in the CDN status slug means that it will be unable to get the CDN status.
`roblox-s-cdn-api-endpoint` should just be `cdn-api-endpoint`